### PR TITLE
Add microphysics submodule and updated graupel lookup table support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics"]
+	path = src/core_atmosphere/physics/physics_wrf/GSL_cloud_physics
+	url = https://github.com/AndersJensen-NOAA/GSL_cloud_physics.git

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -53,7 +53,7 @@ core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
 core_physics_wrf: core_physics_init core_physics_mmm
-	(cd physics_wrf; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_wrf; cp ../GSL_cloud_physics/* .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)

--- a/src/core_atmosphere/physics/Makefile
+++ b/src/core_atmosphere/physics/Makefile
@@ -53,7 +53,7 @@ core_physics_mmm: core_physics_init
 	(cd physics_mmm; $(MAKE) all)
 
 core_physics_wrf: core_physics_init core_physics_mmm
-	(cd physics_wrf; cp ../GSL_cloud_physics/* .; $(MAKE) all COREDEF="$(COREDEF)")
+	(cd physics_wrf; cp ./GSL_cloud_physics/* .; $(MAKE) all COREDEF="$(COREDEF)")
 
 core_physics_init: $(OBJS_init)
 	ar -ru libphys.a $(OBJS_init)

--- a/src/core_atmosphere/physics/mpas_atmphys_finalize.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_finalize.F
@@ -57,7 +57,7 @@
  if(allocated(tcg_racg) ) deallocate(tcg_racg ) 
  if(allocated(tmr_racg) ) deallocate(tmr_racg )
  if(allocated(tcr_gacr) ) deallocate(tcr_gacr )
- if(allocated(tmg_gacr) ) deallocate(tmg_gacr )
+! if(allocated(tmg_gacr) ) deallocate(tmg_gacr )
  if(allocated(tnr_racg) ) deallocate(tnr_racg )
  if(allocated(tnr_gacr) ) deallocate(tnr_gacr )
  if(allocated(tcs_racs1)) deallocate(tcs_racs1)

--- a/src/core_atmosphere/physics/physics_wrf/Makefile
+++ b/src/core_atmosphere/physics/physics_wrf/Makefile
@@ -19,6 +19,8 @@ OBJS = \
 	module_cu_ntiedtke.o           \
 	module_cu_kfeta.o              \
 	module_mp_kessler.o            \
+	module_mp_thompson_params.o    \
+	module_mp_thompson_main.o      \
 	module_mp_thompson.o           \
 	module_mp_thompson_cldfra3.o   \
 	module_mp_wsm6.o               \
@@ -46,6 +48,10 @@ physics_wrf: $(OBJS)
 	ar -ru ./../libphys.a $(OBJS)
 
 # DEPENDENCIES:
+module_mp_thompson.o: \
+	module_mp_thompson_params.o \
+	module_mp_thompson_main.o
+
 module_bl_mynn.o: \
 	module_cam_error_function.o
 

--- a/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
+++ b/src/core_atmosphere/utils/atmphys_build_tables_thompson.F
@@ -47,11 +47,11 @@
     call print_parallel_mesg('MP_THOMPSON_QRacrQG_DATA.DBL')
     return
  end if
- call qr_acr_qg
+ call qr_acr_qg(1)
  write(mp_unit) tcg_racg
  write(mp_unit) tmr_racg
  write(mp_unit) tcr_gacr
- write(mp_unit) tmg_gacr
+! write(mp_unit) tmg_gacr
  write(mp_unit) tnr_racg
  write(mp_unit) tnr_gacr
  close(unit=mp_unit)


### PR DESCRIPTION
This PR adds Thompson microphysics submodule support for MPAS.

This PR modifies the scripts that build the Thompson graupel lookup table to support 2-moment graupel with backwards compatibility for 1-moment graupel. 

