### PR TITLE
Two quick MPAS fixes

### DIFF
--- a/src/core_atmosphere/physics/physics_wrf/module_sf_ruclsm.F
+++ b/src/core_atmosphere/physics/physics_wrf/module_sf_ruclsm.F
@@ -502,7 +502,7 @@ contains
        keepfr3dflag(i,k,j)=0.
             enddo
 !--- initializing snow fraction, thereshold = 32 mm of snow water or ~100 mm of snow height
-call physics_message('!--- initializing inside snow temp if it is not defined')
+! call physics_message('!--- initializing inside snow temp if it is not defined')
        if((soilt1(i,j) .lt. 170.) .or. (soilt1(i,j) .gt.400.)) then
          if(snowc(i,j).gt.0.) then
            soilt1(i,j)=0.5*(soilt(i,j)+tso(i,1,j))

--- a/src/core_init_atmosphere/mpas_init_atm_cases.F
+++ b/src/core_init_atmosphere/mpas_init_atm_cases.F
@@ -244,9 +244,8 @@ module init_atm_cases
             call init_atm_case_gfs(block_ptr, mesh, nCells, nEdges, nVertLevels, fg, state, &
                                    diag, diag_physics, block_ptr % dimensions, block_ptr % configs)
 
-            call init_microphysics_aerosols(mesh, state, diag, block_ptr % configs)
-            
             if (config_met_interp) then
+               call init_microphysics_aerosols(mesh, state, diag, block_ptr % configs)
                call physics_initialize_real(mesh, fg, domain % dminfo, block_ptr % dimensions, block_ptr % configs)
             end if
 


### PR DESCRIPTION
1. Removes a message from RUC that produces too much output in the log file.
2. Moves the call to initialize microphysics aerosols to the config_met_interp loop, so that it won't get called when creating static files.  

